### PR TITLE
Allow top level configuration points

### DIFF
--- a/lib/custom_configuration/configuration.rb
+++ b/lib/custom_configuration/configuration.rb
@@ -3,9 +3,15 @@ module CustomConfiguration
     def initialize
       @configurations = Hash.new
     end
-    
+
     def method_missing(method, *args)
-      @configurations[method] ||= ActiveSupport::OrderedOptions.new
+      if method =~ /=$/
+        @configurations[$`.to_sym] = args.first
+      else
+        @configurations.fetch(method) {
+          @configurations[method] = ActiveSupport::OrderedOptions.new
+        }
+      end
     end
   end
 end

--- a/test/custom_configuration_test.rb
+++ b/test/custom_configuration_test.rb
@@ -5,12 +5,12 @@ class CustomConfigurationTest < ActiveSupport::TestCase
   setup do
     @config = Rails.configuration.x
   end
-  
+
   test 'any top level configuration point is accessible' do
-    @config.resque.inline_jobs = :always
-    assert_equal :always, @config.resque.inline_jobs
+    @config.inline_jobs = :always
+    assert_equal :always, @config.inline_jobs
   end
-  
+
   test 'you can set multiple points and they are remembered' do
     @config.resque.inline_jobs = :always
     @config.resque.timeout     = 60
@@ -18,7 +18,7 @@ class CustomConfigurationTest < ActiveSupport::TestCase
     assert_equal :always, @config.resque.inline_jobs
     assert_equal 60, @config.resque.timeout
   end
-  
+
   test 'unset points are nil' do
     assert_nil @config.resque.nothing_here
   end


### PR DESCRIPTION
We ran into the same problem as https://github.com/dhh/custom_configuration/issues/4 and I believe it is a bug in this gem. We are trying to use it on a Rails 4.0 application. In Rails 4.2, top level configuration points are supported.

I took the code in this PR directly from the 4.2-stable rails branch and fixed the test for top level as well.